### PR TITLE
Check for Linux player in DisplayManager

### DIFF
--- a/src/UI/DisplayManager.cs
+++ b/src/UI/DisplayManager.cs
@@ -12,7 +12,7 @@ namespace UnityExplorer.UI
         public static int Width => ActiveDisplay.renderingWidth;
         public static int Height => ActiveDisplay.renderingHeight;
 
-        public static Vector3 MousePosition => Application.isEditor
+        public static Vector3 MousePosition => Application.isEditor || Application.platform == RuntimePlatform.LinuxPlayer
             ? InputManager.MousePosition
             : Display.RelativeMouseAt(InputManager.MousePosition);
 


### PR DESCRIPTION
This PR adds a Linux check for the mouse position property so people can use Unity Explorer on Linux at least on the primary monitor until a better solution is found.
Issue describing the bug: https://github.com/sinai-dev/UnityExplorer/issues/167