### PR TITLE
fix:GameObjectInspector can't show

### DIFF
--- a/src/Inspectors/GameObjectInspector.cs
+++ b/src/Inspectors/GameObjectInspector.cs
@@ -11,7 +11,7 @@ namespace UnityExplorer.Inspectors
 {
     public class GameObjectInspector : InspectorBase
     {
-        public new GameObject Target => base.Target as GameObject;
+        public new GameObject Target => base.Target.TryCast<GameObject>();
 
         public GameObject Content;
 
@@ -31,7 +31,7 @@ namespace UnityExplorer.Inspectors
         {
             base.OnBorrowedFromPool(target);
 
-            base.Target = target as GameObject;
+            base.Target = target.TryCast<GameObject>();
 
             Controls.UpdateGameObjectInfo(true, true);
             Controls.TransformControl.UpdateTransformControlValues(true);

--- a/src/Inspectors/InspectorManager.cs
+++ b/src/Inspectors/InspectorManager.cs
@@ -27,7 +27,7 @@ namespace UnityExplorer
             if (TryFocusActiveInspector(obj))
                 return;
 
-            if (obj is GameObject)
+            if (obj.TryCast<GameObject>() is not null)
                 CreateInspector<GameObjectInspector>(obj);
             else
                 CreateInspector<ReflectionInspector>(obj, false, parent);


### PR DESCRIPTION
GameObject Inspector does not work with the latest BepInEx builds, etc., so this is a fix for that.
Mainly because the L30 part of `src/Inspectors/InspectorManager.cs `was `false` and didn't work, I have changed the check to using `TryCast`.